### PR TITLE
Make Logger Class Static Methods Thread-Safe

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,6 @@
+
+* Made logger class (JRuby Wrapper) thread safe
+
 1.0.0.rc1
 
 * setting level now accepts ::Logger constants and symbols

--- a/lib/log4jruby.rb
+++ b/lib/log4jruby.rb
@@ -1,3 +1,4 @@
+require 'log4jruby/read_write_hash'
 require 'log4jruby/logger'
 require 'log4jruby/logger_for_class'
 

--- a/lib/log4jruby/logger.rb
+++ b/lib/log4jruby/logger.rb
@@ -27,7 +27,7 @@ module Log4jruby
 
     class << self
       def logger_mapping
-        @logger_mapping ||= {}
+        @logger_mapping ||= ReadWriteHash.new
       end
       
       # get Logger for name

--- a/lib/log4jruby/read_write_hash.rb
+++ b/lib/log4jruby/read_write_hash.rb
@@ -1,0 +1,34 @@
+
+module Log4jruby
+
+  # Pure Ruby Hash with a protection of ReadWriteLock for thread-safety
+  class ReadWriteHash
+
+    def initialize
+      @kvhash = {}
+      @rwlock = Java::java.util.concurrent.locks.ReentrantReadWriteLock.new
+      @rlock = @rwlock.readLock
+      @wlock = @rwlock.writeLock
+    end
+
+    def [] (key)
+      begin
+        @rlock.lock
+        return @kvhash[key] 
+      ensure
+        @rlock.unlock
+      end
+    end
+
+    def []= (key, value)
+      begin
+        @wlock.lock
+        @kvhash[key] = value
+      ensure
+        @wlock.unlock
+      end
+    end
+
+  end
+
+end

--- a/spec/log4jruby/read_write_hash_spec.rb
+++ b/spec/log4jruby/read_write_hash_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+require 'log4jruby'
+
+module Log4jruby
+  describe ReadWriteHash do
+
+    subject { Logger.get('Test', :level => :debug) }
+
+    describe "Simple Hash Access" do
+
+      def basic_test(id, h, max)
+        max.times do |i|
+          h["foo-#{id}-#{i}"] = "bar-#{id}-#{i}"
+
+          i.times do |j|
+            h["foo-#{id}-#{i}"].should == "bar-#{id}-#{i}"
+          end
+        end
+      end
+
+      it "single-threaded" do
+        h = ReadWriteHash.new
+        basic_test(1, h, 20)
+      end
+
+      it "multi-threaded same-keys" do
+        h = ReadWriteHash.new
+        10.times do |i|
+          Thread.new { basic_test(1, h, 20) }
+        end
+      end
+
+      it "multi-threaded different-keys" do
+        h = ReadWriteHash.new
+        10.times do |i|
+          Thread.new { basic_test(i, h, 20) }
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Logger Class (a JRuby Wrapper) (logger.rb) has static methods which when used in multi-threaded environments leads to issues.  The issue comes from a Hash which is not protected for thread-safe access.  I have created a ReadWriteHash (read_write_hash.rb) a pure Ruby Hash protected with ReadWriteLock of Java.  I have added specs as well.  We have hit this issue in our production where in Hash got corrupted such a way that threads got into busy loops in trying to get (or getting) a cached wrapper object.  The issue is: https://github.com/lenny/log4jruby/issues/2