### PR TITLE
add support for Logger's silence method

### DIFF
--- a/lib/log4jruby/logger.rb
+++ b/lib/log4jruby/logger.rb
@@ -1,6 +1,7 @@
 require 'log4jruby/support/log4j_args'
 
 require 'logger'
+require 'log4jruby/logger_silencer'
 
 module Log4jruby
 
@@ -11,6 +12,8 @@ module Log4jruby
   # * Ruby and Java exceptions are logged with backtraces.
   # * fileName, lineNumber, methodName available to appender layouts via MDC variables(e.g. %X{lineNumber})
   class Logger
+    include Log4jruby::LoggerSilencer
+
     LOG4J_LEVELS = {
         Java::org.apache.log4j.Level::DEBUG => ::Logger::DEBUG,
         Java::org.apache.log4j.Level::INFO => ::Logger::INFO,

--- a/lib/log4jruby/logger_silencer.rb
+++ b/lib/log4jruby/logger_silencer.rb
@@ -1,0 +1,19 @@
+
+module Log4jruby
+  module LoggerSilencer
+    def self.included(base)
+      base.send :include, InstanceMethods
+    end
+
+    module InstanceMethods
+      def silence(temporary_level = ::Logger::ERROR)
+        begin
+          old_logger_level, self.level = level, temporary_level
+          yield self
+        ensure
+          self.level = old_logger_level
+        end
+      end
+    end
+  end
+end

--- a/spec/log4jruby/logger_silencer_spec.rb
+++ b/spec/log4jruby/logger_silencer_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'log4jruby'
+
+module Log4jruby
+  describe LoggerSilencer do
+    before { Logger.reset }
+    subject { Logger.get('Test', :level => :debug) }
+
+    describe '#silence', 'temporarily changes the log level' do
+      it 'should change the log level inside the block' do
+        subject.silence(::Logger::WARN) do
+          expect(subject.level).to eq(::Logger::WARN)
+        end
+      end
+
+      it 'should restore the log level after the block' do
+        subject.silence(::Logger::WARN) do
+        end
+        expect(subject.level).to eq(::Logger::DEBUG)
+      end
+
+      it 'defaults to error level' do
+        subject.silence do
+          expect(subject.level).to eq(::Logger::ERROR)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Log4jruby::LoggerSilencer
  #silence temporarily changes the log level
    should change the log level inside the block
    should restore the log level after the block
    defaults to error level