### PR TITLE
Restore jruby 9.1.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # log4jruby Changelog
 
+## v3.0.0.rc2
+
+* Restored support for JRuby 9.1.x/Ruby 2.3
+
 ## v3.0.0.rc1
 
 * JRuby 9.3.x/Ruby 2.6 support - Ruby >= 2.6.8 now required

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ The default Log4jruby formatter outputs `progname` and `msg` only (as opposed to
 Severity, timestamp, and backtraces are handed according to your `Log4j` configuration. 
 E.g. [PatternLayout](https://logging.apache.org/log4j/2.x/manual/layouts.html).
 
+* For JRuby versions < 9.3, Ruby exceptions are not passed directly to the `Throwable` arg of log4j. Instead,
+  backtraces are included in the log message by the default formatter. This means that `%throwable` in
+  the log4j config will not affect ruby exceptions for Jruby < 9.3.
+
 The output of the `formatter` is passed as the `message` parameter of the [Log4j log methods](https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Category.html#log(org.apache.log4j.Priority,%20java.lang.Object).
 
 ## Development

--- a/examples/nested_ruby_exceptions.rb
+++ b/examples/nested_ruby_exceptions.rb
@@ -12,17 +12,17 @@ logger = Log4jruby::Logger.get('test', tracing: true, level: :debug)
 def foo
   bar
 rescue StandardError
-  raise 'raised from foo'
+  raise 'foo error'
 end
 
 def bar
   baz
 rescue StandardError
-  raise 'raised from bar'
+  raise 'bar error'
 end
 
 def baz
-  raise 'raised from baz'
+  raise 'baz error'
 end
 
 begin

--- a/lib/log4jruby/logger.rb
+++ b/lib/log4jruby/logger.rb
@@ -4,6 +4,10 @@ require 'log4jruby/support/log4j_args'
 require 'log4jruby/support/levels'
 require 'log4jruby/support/location'
 require 'log4jruby/support/log_manager'
+require 'log4jruby/support/formatter'
+require 'log4jruby/support/legacy_shim_formatter'
+require 'log4jruby/support/jruby_version'
+
 require 'logger'
 
 module Log4jruby
@@ -121,7 +125,7 @@ module Log4jruby
       return @formatter if defined?(@formatter)
 
       @formatter = if self == Logger.root
-                     ->(_severity, _datetime, progname, msg) { "-- #{progname}: #{msg}" }
+                     new_default_formatter
                    else
                      parent.formatter
                    end
@@ -166,6 +170,11 @@ module Log4jruby
       else
         @log4j_logger.send(level, msg, throwable)
       end
+    end
+
+    def new_default_formatter
+      Support::JrubyVersion.native_ruby_stacktraces_supported? ? Support::Formatter.new :
+        Support::LegacyShimFormatter.new
     end
   end
 end

--- a/lib/log4jruby/logger.rb
+++ b/lib/log4jruby/logger.rb
@@ -173,8 +173,11 @@ module Log4jruby
     end
 
     def new_default_formatter
-      Support::JrubyVersion.native_ruby_stacktraces_supported? ? Support::Formatter.new :
+      if Support::JrubyVersion.native_ruby_stacktraces_supported?
+        Support::Formatter.new
+      else
         Support::LegacyShimFormatter.new
+      end
     end
   end
 end

--- a/lib/log4jruby/support/formatter.rb
+++ b/lib/log4jruby/support/formatter.rb
@@ -2,8 +2,12 @@
 
 module Log4jruby
   module Support
+    # Default ruby Logger formatter
+    # This formatter mimics
+    # [Logger::Formatter](https://ruby-doc.org/stdlib-2.6.4/libdoc/logger/rdoc/Logger/Formatter.html)
+    # but excludes log level and timestamp to leave it for the Log4j config
     class Formatter
-      def call(severity, time, progname, msg)
+      def call(_severity, _time, progname, msg)
         "-- #{progname}: #{msg}"
       end
     end

--- a/lib/log4jruby/support/formatter.rb
+++ b/lib/log4jruby/support/formatter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Log4jruby
+  module Support
+    class Formatter
+      def call(severity, time, progname, msg)
+        "-- #{progname}: #{msg}"
+      end
+    end
+  end
+end

--- a/lib/log4jruby/support/jruby_version.rb
+++ b/lib/log4jruby/support/jruby_version.rb
@@ -1,5 +1,9 @@
+# frozen_string_literal: true
+
 module Log4jruby
   module Support
+    # Class for explicitly marking JRuby version specific code.
+    # Find consumers and remove this and references when no longer needed.
     class JrubyVersion
       class << self
         def native_ruby_stacktraces_supported?

--- a/lib/log4jruby/support/jruby_version.rb
+++ b/lib/log4jruby/support/jruby_version.rb
@@ -1,0 +1,11 @@
+module Log4jruby
+  module Support
+    class JrubyVersion
+      class << self
+        def native_ruby_stacktraces_supported?
+          Gem::Version.new(JRUBY_VERSION) >= Gem::Version.new('9.3')
+        end
+      end
+    end
+  end
+end

--- a/lib/log4jruby/support/legacy_shim_formatter.rb
+++ b/lib/log4jruby/support/legacy_shim_formatter.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Log4jruby
+  module Support
+    class LegacyShimFormatter
+      def call(severity, time, progname, msg)
+        "-- #{msg2str(progname)}: #{msg2str(msg)}"
+      end
+
+      private
+
+      def msg2str(msg)
+        case msg
+        when ::String
+          msg
+        when ::Exception
+          stringify_exception_chain(msg)
+        else
+          msg.inspect
+        end
+      end
+
+      def stringify_exception_chain(exception)
+        if exception.cause
+          "#{stringify_exception(exception)}\nCaused by: #{stringify_exception_chain(exception.cause)}"
+        else
+          stringify_exception(exception)
+        end
+      end
+
+      def stringify_exception(exception)
+        "#{ exception.message } (#{ exception.class })\n\t#{ exception.backtrace&.join("\n\t")}"
+      end
+    end
+  end
+end

--- a/lib/log4jruby/support/legacy_shim_formatter.rb
+++ b/lib/log4jruby/support/legacy_shim_formatter.rb
@@ -19,23 +19,15 @@ module Log4jruby
         when ::String
           msg
         when ::Exception
-          stringify_exception_chain(msg)
+          exception2str(msg)
         else
           msg.inspect
         end
       end
 
-      def stringify_exception_chain(exception)
-        if exception.cause
-          "#{stringify_exception(exception)}\nCaused by: " \
-            "#{stringify_exception_chain(exception.cause)}"
-        else
-          stringify_exception(exception)
-        end
-      end
-
-      def stringify_exception(exception)
-        "#{exception.message} (#{exception.class})\n\t#{exception.backtrace&.join("\n\t")}"
+      def exception2str(exception)
+        "#{exception.message} (#{exception.class})\n\t#{exception.backtrace&.join("\n\t")}" \
+          "#{"\nCaused by: #{exception2str(exception.cause)}" if exception.cause}"
       end
     end
   end

--- a/lib/log4jruby/support/legacy_shim_formatter.rb
+++ b/lib/log4jruby/support/legacy_shim_formatter.rb
@@ -2,8 +2,13 @@
 
 module Log4jruby
   module Support
+    # Default ruby Logger formatter for Jruby < 9.3.x
+    # This formatter mimics
+    # [Logger::Formatter](https://ruby-doc.org/stdlib-2.6.4/libdoc/logger/rdoc/Logger/Formatter.html)
+    # but excludes log level and timestamp (delegated to Log4j).
+    # It also appends full backtraces with nested causes.
     class LegacyShimFormatter
-      def call(severity, time, progname, msg)
+      def call(_severity, _time, progname, msg)
         "-- #{msg2str(progname)}: #{msg2str(msg)}"
       end
 
@@ -22,14 +27,15 @@ module Log4jruby
 
       def stringify_exception_chain(exception)
         if exception.cause
-          "#{stringify_exception(exception)}\nCaused by: #{stringify_exception_chain(exception.cause)}"
+          "#{stringify_exception(exception)}\nCaused by: " \
+            "#{stringify_exception_chain(exception.cause)}"
         else
           stringify_exception(exception)
         end
       end
 
       def stringify_exception(exception)
-        "#{ exception.message } (#{ exception.class })\n\t#{ exception.backtrace&.join("\n\t")}"
+        "#{exception.message} (#{exception.class})\n\t#{exception.backtrace&.join("\n\t")}"
       end
     end
   end

--- a/lib/log4jruby/support/log4j_args.rb
+++ b/lib/log4jruby/support/log4j_args.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'log4jruby/support/jruby_version'
 
 module Log4jruby
   module Support
@@ -37,7 +38,8 @@ module Log4jruby
         end
 
         def exception(obj)
-          obj.is_a?(::Exception) || obj.is_a?(Java::java.lang.Throwable) ? obj : nil
+          (JrubyVersion.native_ruby_stacktraces_supported? && obj.is_a?(::Exception)) ||
+            obj.is_a?(Java::java.lang.Throwable) ? obj : nil
         end
       end
     end

--- a/lib/log4jruby/support/log4j_args.rb
+++ b/lib/log4jruby/support/log4j_args.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'log4jruby/support/jruby_version'
 
 module Log4jruby
@@ -38,8 +39,10 @@ module Log4jruby
         end
 
         def exception(obj)
-          (JrubyVersion.native_ruby_stacktraces_supported? && obj.is_a?(::Exception)) ||
-            obj.is_a?(Java::java.lang.Throwable) ? obj : nil
+          if (JrubyVersion.native_ruby_stacktraces_supported? && obj.is_a?(::Exception)) ||
+             obj.is_a?(Java::java.lang.Throwable)
+            obj
+          end
         end
       end
     end

--- a/lib/log4jruby/support/log_manager.rb
+++ b/lib/log4jruby/support/log_manager.rb
@@ -17,7 +17,7 @@ module Log4jruby
         end
 
         def get_or_create(name)
-          raise 'name required' if name.to_s.match?(/^\s+$/)
+          raise 'name required' if name.to_s.match(/^\s+$/)
 
           @mutex.synchronize do
             @loggers[name] ||= new_logger(name)

--- a/lib/log4jruby/version.rb
+++ b/lib/log4jruby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Log4jruby
-  VERSION = '3.0.0.rc1'
+  VERSION = '3.0.0.rc2'
 end

--- a/log4jruby.gemspec
+++ b/log4jruby.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.platform = 'java'
   gem.license = 'MIT'
 
-  # jruby >= 9.3.0.0
+  # jruby >= 9.1.x
   gem.required_ruby_version = '~> 2.3.3'
   gem.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/log4jruby.gemspec
+++ b/log4jruby.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |gem|
   gem.license = 'MIT'
 
   # jruby >= 9.3.0.0
-  gem.required_ruby_version = '~> 2.6.8'
+  gem.required_ruby_version = '~> 2.3.3'
   gem.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/log4jruby/logger_spec.rb
+++ b/spec/log4jruby/logger_spec.rb
@@ -150,13 +150,24 @@ module Log4jruby
           subject.send(level, 7)
         end
 
-        it 'should log ruby exceptions as jruby adapted java RuntinmeExceptions' do
-          expect(log4j).to receive(level).with(/some error/,
-                                               kind_of(Java::java.lang.RuntimeException))
-          begin
-            raise 'some error'
-          rescue StandardError => e
-            subject.send(level, e)
+        if Support::JrubyVersion.native_ruby_stacktraces_supported?
+          it 'sends jruby adapted ruby exceptions directly to log4j' do
+            expect(log4j).to receive(level).with(/some error/,
+                                                 kind_of(Java::java.lang.RuntimeException))
+            begin
+              raise 'some error'
+            rescue StandardError => e
+              subject.send(level, e)
+            end
+          end
+        else
+          it 'does not send ruby exceptions directly to log4j' do
+            expect(log4j).to receive(level).with(/some error/, nil)
+            begin
+              raise 'some error'
+            rescue StandardError => e
+              subject.send(level, e)
+            end
           end
         end
 


### PR DESCRIPTION
Old Rails 4.2 apps are not compatible with Ruby > 2.3. Keeping jruby-9.1.x support for now will allow migrating log4j2 without having to upgrade Rails apps. 